### PR TITLE
Fix password hashing on Backpack v4

### DIFF
--- a/src/app/Http/Controllers/UserCrudController.php
+++ b/src/app/Http/Controllers/UserCrudController.php
@@ -115,12 +115,18 @@ class UserCrudController extends CrudController
     {
         // Remove fields not present on the user.
         $request->request->remove('password_confirmation');
+        $crud_request = $this->crud->request->request;
 
         // Encrypt password if specified.
         if ($request->input('password')) {
-            $request->request->set('password', bcrypt($request->input('password')));
+            $hashed_password = bcrypt($request->input('password'));
+
+            $request->request->set('password', $hashed_password);
+            $crud_request->set('password', $hashed_password);
+            $crud_request->set('password_confirmation', $hashed_password);
         } else {
             $request->request->remove('password');
+            $crud_request->remove('password');
         }
     }
 }


### PR DESCRIPTION
Potential fix for #9.

This modifies the `ParameterBag` request stored in `$this->crud->request->request` so that when Backpack v4 retrieves the request to then store.

This may not be compatible with older Backpack versions, so please investigate that.

The way this plugin is written, in Backpack v4 the request is validated twice. Once in this plugin, and once in Backpack itself. That isn't changed by this PR, but it's something to think about.