### PR TITLE
added backslash to CrudTrait usage in order not tot trigger error

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ namespace App;
 
 class BackpackUser extends User
 {
-    use Backpack\CRUD\app\Models\Traits\CrudTrait; // <--- Add this line
+    use \Backpack\CRUD\app\Models\Traits\CrudTrait; // <--- Add this line
 
     // ...
 ```


### PR DESCRIPTION
Otherwise I get this beauty:

![Screenshot 2020-12-16 at 12 01 42](https://user-images.githubusercontent.com/1032474/102373392-cf5e3980-3fc8-11eb-8a85-5834e6984d74.png)
